### PR TITLE
feat(LandingPage): add mobile-only AO Technologies overlay

### DIFF
--- a/src/components/LandingPage/LandingPage.css
+++ b/src/components/LandingPage/LandingPage.css
@@ -265,6 +265,25 @@ background: linear-gradient(135deg, rgba(15, 15, 35, 0.95) 0%, rgba(26, 26, 58, 
   }
 }
 
+/* Mobile-only AO Technologies overlay */
+.mobile-ao-tech-overlay {
+  position: fixed;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-50%);
+  font-family: 'Roboto', sans-serif;
+  font-size: 3rem;
+  font-weight: 700;
+  color: white;
+  text-align: right;
+  z-index: 1000;
+  pointer-events: none;
+  user-select: none;
+  white-space: nowrap;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  letter-spacing: 0.1em;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .emerging-title {
@@ -286,6 +305,11 @@ background: linear-gradient(135deg, rgba(15, 15, 35, 0.95) 0%, rgba(26, 26, 58, 
     letter-spacing: 0.1em;
   }
   
+  /* Mobile AO Technologies overlay responsive sizing */
+  .mobile-ao-tech-overlay {
+    font-size: 2.5rem;
+  }
+  
   /* Disable Spline interactions on mobile to allow scrolling */
   .spline-container {
     pointer-events: none;
@@ -304,6 +328,12 @@ background: linear-gradient(135deg, rgba(15, 15, 35, 0.95) 0%, rgba(26, 26, 58, 
   .ao-tech-text {
     font-size: 1.8rem;
     bottom: 20%;
+    letter-spacing: 0.05em;
+  }
+  
+  /* Mobile AO Technologies overlay for small screens */
+  .mobile-ao-tech-overlay {
+    font-size: 2rem;
     letter-spacing: 0.05em;
   }
   

--- a/src/components/LandingPage/LandingPage.js
+++ b/src/components/LandingPage/LandingPage.js
@@ -1,13 +1,12 @@
 import React, { useEffect, useState, useRef } from 'react';
 import Spline from '@splinetool/react-spline';
-import { motion, useScroll, useTransform, useMotionValue } from 'framer-motion';
+import { motion, useScroll, useTransform } from 'framer-motion';
 import './LandingPage.css';
 
 const LandingPage = () => {
   const [isVisible, setIsVisible] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const containerRef = useRef(null);
-  const scrollY = useMotionValue(0);
   
   const { scrollYProgress } = useScroll({
     target: containerRef,
@@ -18,6 +17,7 @@ const LandingPage = () => {
   const scale = useTransform(scrollYProgress, [0, 0.5, 1], [1, 1.8, 4]);
   const z = useTransform(scrollYProgress, [0, 0.5, 1], [0, -200, -800]);
   const opacity = useTransform(scrollYProgress, [0, 0.6, 1], [1, 0.7, 0]);
+  const mobileTextOpacity = useTransform(scrollYProgress, [0, 0.4], [1, 0]);
   
 
 
@@ -100,18 +100,20 @@ const LandingPage = () => {
             }}
           />
           
-          {/* Large 3D translucent AO Technologies text */}
-          {/* <motion.div 
-            className="ao-tech-text"
-            initial={{ opacity: 0, y: 100 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 2, delay: 1, ease: "easeOut" }}
-            style={{
-              opacity: useTransform(scrollYProgress, [0, 0.3], [1, 0])
-            }}
-          >
-            AO Technologies
-          </motion.div> */}
+          {/* Mobile-only AO Technologies text overlay */}
+          {isMobile && (
+            <motion.div 
+              className="mobile-ao-tech-overlay"
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 1.5, delay: 0.5, ease: "easeOut" }}
+              style={{
+                opacity: mobileTextOpacity
+              }}
+            >
+              AO Technologies
+            </motion.div>
+          )}
         </div>
       </section>
       


### PR DESCRIPTION
Add a fixed position text overlay for mobile devices that displays "AO Technologies" with responsive sizing. The overlay fades out as user scrolls down to maintain clean UI. Removed unused scrollY motion value for better code clarity.